### PR TITLE
[FEAT]: 리프레시 토큰으로 액세스 토큰 재발급 API

### DIFF
--- a/src/main/java/dormease/dormeasedev/domain/users/auth/controller/AuthApi.java
+++ b/src/main/java/dormease/dormeasedev/domain/users/auth/controller/AuthApi.java
@@ -5,6 +5,7 @@ import dormease.dormeasedev.domain.users.auth.dto.request.ModifyReq;
 import dormease.dormeasedev.domain.users.auth.dto.request.SignInReq;
 import dormease.dormeasedev.domain.users.auth.dto.request.SignUpReq;
 import dormease.dormeasedev.domain.users.auth.dto.response.CheckLoginIdRes;
+import dormease.dormeasedev.domain.users.auth.dto.response.ReissueRes;
 import dormease.dormeasedev.domain.users.auth.dto.response.SignInRes;
 import dormease.dormeasedev.global.exception.ExceptionResponse;
 import dormease.dormeasedev.global.security.UserDetailsImpl;
@@ -103,7 +104,7 @@ public interface AuthApi {
                     content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))}),
     })
     @PostMapping(value = "/sign-out")
-    ResponseEntity<?> signout(
+    ResponseEntity<?> signOut(
             @Parameter(description = "Accesstoken을 입력해주세요.", required = true) @AuthenticationPrincipal UserDetailsImpl userDetailsImpl
     );
 
@@ -121,5 +122,21 @@ public interface AuthApi {
     @GetMapping("/loginId/{loginId}")
     ResponseEntity<dormease.dormeasedev.global.common.ApiResponse> checkLoginId(
             @Parameter(description = "검사할 아이디를 입력해주세요.", required = true) @PathVariable(value = "loginId") String loginId
+    );
+
+    @Operation(summary = "리토큰 재발급 API", description = "리프레시 토큰으로 액세스 토큰 재발급을 진행합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", description = "토큰 재발급 성공",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ReissueRes.class))}
+            ),
+            @ApiResponse(
+                    responseCode = "400", description = "토큰 재발급 실패",
+                    content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ExceptionResponse.class))}
+            ),
+    })
+    @GetMapping("/reissue")
+    ResponseEntity<dormease.dormeasedev.global.common.ApiResponse> reissue(
+            @Parameter(description = "리프레시 토큰을 입력해주세요.", required = true) @RequestParam(value = "refreshToken") String refreshToken
     );
 }

--- a/src/main/java/dormease/dormeasedev/domain/users/auth/controller/AuthController.java
+++ b/src/main/java/dormease/dormeasedev/domain/users/auth/controller/AuthController.java
@@ -65,8 +65,8 @@ public class AuthController implements AuthApi {
 
     @Override
     @PostMapping(value = "/sign-out")
-    public ResponseEntity<?> signout(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
-        authService.signout(userDetailsImpl);
+    public ResponseEntity<?> signOut(@AuthenticationPrincipal UserDetailsImpl userDetailsImpl) {
+        authService.signOut(userDetailsImpl);
         return ResponseEntity.noContent().build();
     }
 
@@ -76,6 +76,15 @@ public class AuthController implements AuthApi {
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)
                 .information(authService.checkLoginId(loginId))
+                .build();
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse> reissue(@RequestParam(value = "refreshToken") String refreshToken) {
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(authService.reissue(refreshToken))
                 .build();
         return ResponseEntity.ok(apiResponse);
     }

--- a/src/main/java/dormease/dormeasedev/domain/users/auth/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/dormease/dormeasedev/domain/users/auth/domain/repository/RefreshTokenRepository.java
@@ -13,4 +13,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Stri
 
     // 소유자의 loginId가 파라미터로 받은 loginId면서 재발급 횟수가 파라미터로 받은 reissueCount보다 작은 RefreshToken 객체를 반환
     Optional<RefreshToken> findByLoginIdAndReissueCountLessThan(String loginId, long reissueCount);
+
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/dormease/dormeasedev/domain/users/auth/dto/response/ReissueRes.java
+++ b/src/main/java/dormease/dormeasedev/domain/users/auth/dto/response/ReissueRes.java
@@ -1,0 +1,17 @@
+package dormease.dormeasedev.domain.users.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ReissueRes {
+
+    @Schema(
+            type = "string",
+            example = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsInJvbGUiOiJjdnZ6M0BuYXZlci5jb20iLCJpZCI6ImN2dnozQG5hdmVyLmNvbSIsImV4cCI6MTcyMzYyODQ2MiwiZW1haWwiOiJjdnZ6M0BuYXZlci5jb20ifQ.b8_v-GTWTFxQVmhH1jg-JUERpVXGe_tFg4-Tjv6F8DtymMMKgxicCF6dWlsHxJEhyKL3k-Z4qnCeVq_EcH54eg",
+            description= "새로 발급된 access token을 출력합니다."
+    )
+    private String accessToken;
+}

--- a/src/main/java/dormease/dormeasedev/domain/users/auth/exception/UserNotFoundException.java
+++ b/src/main/java/dormease/dormeasedev/domain/users/auth/exception/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package dormease.dormeasedev.domain.users.auth.exception;
+
+import dormease.dormeasedev.global.exception.BusinessException;
+
+public class UserNotFoundException extends BusinessException {
+
+    public UserNotFoundException() {
+        super("회원을 찾을 수 없습니다.");
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 적어주세요
- [x] 리프레시 토큰으로 액세스 토큰 재발급 API


## 📷 스크린샷

### 작업 화면
> 이번 PR에서 작업한 화면을 캡쳐해주세요

x

### 테스트 결과
> 작업한 내용의 실행 결과를 캡쳐해주세요 (포스트맨 혹은 테스트 코드 실행 결과)

![image](https://github.com/user-attachments/assets/c6ebc7eb-d75e-458f-815d-df9fa949578b)


## #️⃣ 연관된 이슈
> ex) # 이슈번호

closes #168 

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 예외 처리를 이렇게 해도 괜찮을까요? / ~~부분 주의 깊게 봐주세요

토큰 저장 레디스 도입

rdb에 토큰 저장 문제
1. 로그아웃 시 accesstoken blacklist
2. 리프레시 토큰 만료 시 delete
3. 토큰 재발급 후 재발급 전의 액세스 토큰(만료 전)으로 요청 시 가능
문제가 있음

